### PR TITLE
simplify `check_visibility` system creations

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -351,11 +351,6 @@ impl Plugin for PbrPlugin {
                         .after(SimulationLightSystems::AssignLightsToClusters),
                     check_visibility::<WithLight>
                         .in_set(VisibilitySystems::CheckVisibility)
-                        .after(VisibilitySystems::CalculateBounds)
-                        .after(VisibilitySystems::UpdateOrthographicFrusta)
-                        .after(VisibilitySystems::UpdatePerspectiveFrusta)
-                        .after(VisibilitySystems::UpdateProjectionFrusta)
-                        .after(VisibilitySystems::VisibilityPropagate)
                         .after(TransformSystem::TransformPropagate),
                     check_light_mesh_visibility
                         .in_set(SimulationLightSystems::CheckLightVisibility)

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -78,7 +78,7 @@ use bevy_render::{
     render_resource::{Shader, TextureUsages},
     view::{
         check_visibility, prepare_view_targets, InheritedVisibility, Msaa, ViewVisibility,
-        Visibility, VisibilitySystems,
+        Visibility,
     },
     ExtractSchedule, Render, RenderApp, RenderSet,
 };
@@ -168,14 +168,7 @@ impl Plugin for MeshletPlugin {
             .insert_resource(Msaa::Off)
             .add_systems(
                 PostUpdate,
-                check_visibility::<WithMeshletMesh>
-                    .in_set(VisibilitySystems::CheckVisibility)
-                    .after(VisibilitySystems::CalculateBounds)
-                    .after(VisibilitySystems::UpdateOrthographicFrusta)
-                    .after(VisibilitySystems::UpdatePerspectiveFrusta)
-                    .after(VisibilitySystems::UpdateProjectionFrusta)
-                    .after(VisibilitySystems::VisibilityPropagate)
-                    .after(TransformSystem::TransformPropagate),
+                check_visibility::<WithMeshletMesh>.after(TransformSystem::TransformPropagate),
             );
     }
 

--- a/crates/bevy_pbr/src/meshlet/mod.rs
+++ b/crates/bevy_pbr/src/meshlet/mod.rs
@@ -78,7 +78,7 @@ use bevy_render::{
     render_resource::{Shader, TextureUsages},
     view::{
         check_visibility, prepare_view_targets, InheritedVisibility, Msaa, ViewVisibility,
-        Visibility,
+        Visibility, VisibilitySystems,
     },
     ExtractSchedule, Render, RenderApp, RenderSet,
 };
@@ -168,7 +168,9 @@ impl Plugin for MeshletPlugin {
             .insert_resource(Msaa::Off)
             .add_systems(
                 PostUpdate,
-                check_visibility::<WithMeshletMesh>.after(TransformSystem::TransformPropagate),
+                check_visibility::<WithMeshletMesh>
+                    .in_set(VisibilitySystems::CheckVisibility)
+                    .after(TransformSystem::TransformPropagate),
             );
     }
 

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -123,11 +123,6 @@ impl Plugin for SpritePlugin {
                         check_visibility::<WithSprite>,
                     )
                         .in_set(VisibilitySystems::CheckVisibility)
-                        .after(VisibilitySystems::CalculateBounds)
-                        .after(VisibilitySystems::UpdateOrthographicFrusta)
-                        .after(VisibilitySystems::UpdatePerspectiveFrusta)
-                        .after(VisibilitySystems::UpdateProjectionFrusta)
-                        .after(VisibilitySystems::VisibilityPropagate)
                         .after(TransformSystem::TransformPropagate),
                 ),
             );

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -137,13 +137,7 @@ impl Plugin for UiPlugin {
         app.add_systems(
             PostUpdate,
             (
-                check_visibility::<WithNode>
-                    .in_set(VisibilitySystems::CheckVisibility)
-                    .after(VisibilitySystems::CalculateBounds)
-                    .after(VisibilitySystems::UpdateOrthographicFrusta)
-                    .after(VisibilitySystems::UpdatePerspectiveFrusta)
-                    .after(VisibilitySystems::UpdateProjectionFrusta)
-                    .after(VisibilitySystems::VisibilityPropagate),
+                check_visibility::<WithNode>.in_set(VisibilitySystems::CheckVisibility),
                 update_target_camera_system.before(UiSystem::Layout),
                 apply_deferred
                     .after(update_target_camera_system)


### PR DESCRIPTION
I believe this is everywhere we were using that long chain of `.after(...)`s.

I'm not sure whether or not we should add `.after(TransformSystem::TransformPropagate),` to `configure_sets` for `CheckVisibility`, since the UI system doesn't seem to use it (which might actually be a bug?).